### PR TITLE
Updated the alias prefixes and suffixes

### DIFF
--- a/dnsfilter/rule_utils.cpp
+++ b/dnsfilter/rule_utils.cpp
@@ -15,7 +15,7 @@ static constexpr int MODIFIERS_DELIMITER = ',';
 static constexpr std::string_view EXCEPTION_MARKER = "@@";
 static constexpr std::string_view SKIPPABLE_PREFIXES[]
         = {"https://", "http://", "http*://", "ws://", "wss://", "ws*://", "://", "//", "*://"};
-static constexpr std::string_view SPECIAL_SUFFIXES[] = {"|", "^", "/", "$all", "$~third-party", "$1p", "$first-party", "/*};
+static constexpr std::string_view SPECIAL_SUFFIXES[] = {"|", "^", "/", "$all", "$~third-party", "$1p", "$first-party", "$network", "/*"};
 static constexpr std::string_view SPECIAL_REGEX_CHARACTERS = "\\^$*+?.()|[]{}";
 
 static const Regex SHORTCUT_REGEXES[] = {

--- a/dnsfilter/rule_utils.cpp
+++ b/dnsfilter/rule_utils.cpp
@@ -14,8 +14,8 @@ static constexpr int MODIFIERS_MARKER = '$';
 static constexpr int MODIFIERS_DELIMITER = ',';
 static constexpr std::string_view EXCEPTION_MARKER = "@@";
 static constexpr std::string_view SKIPPABLE_PREFIXES[]
-        = {"https://", "http://", "http*://", "ws://", "wss://", "ws*://", "://", "//"};
-static constexpr std::string_view SPECIAL_SUFFIXES[] = {"|", "^", "/"};
+        = {"https://", "http://", "http*://", "ws://", "wss://", "ws*://", "://", "//", "*://"};
+static constexpr std::string_view SPECIAL_SUFFIXES[] = {"|", "^", "/", "$all", "$~third-party", "$1p", "$first-party", "/*};
 static constexpr std::string_view SPECIAL_REGEX_CHARACTERS = "\\^$*+?.()|[]{}";
 
 static const Regex SHORTCUT_REGEXES[] = {


### PR DESCRIPTION
If I got anywhere close to understanding the file and folder structure correctly, this PR aims to:
* Allow the use of `$all` in DNS filterlists without needing a conversion process. Directly inspired by https://github.com/AdguardTeam/HostlistsRegistry/issues/197.
* Assumed it was safe *enough* to assume that `$~third-party` entries can be considered suitable for full blocks too. I skipped `$document` and `$third-party` at the time of writing, the former of which means that `$doc` entries in *uBlock Filters - Badware Risks* would still need to be run through a conversion process.
* Added `$network` for good measure.
* Added `*://` and `/*` based on my limited understanding of the [MinerBlock/uBlacklist "Match pattern" syntax](https://github.com/iorate/ublacklist#description).